### PR TITLE
Release/v0.2.6

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,11 +2,32 @@
 
 This directory contains GitHub Actions workflows that automate the CI/CD pipeline for the WAGO CC100 VS Code extension. All workflows are designed to work together to provide a complete development, build, and publishing process.
 
-## 📁 Workflow Overview
+## � Complete Release Process
+
+The workflows follow this automated chain for releasing extensions:
+
+```text
+1. Start Release Branch (Manual) 
+   ↓
+2. Development & Testing on release/v* branch
+   ↓  
+3. Create Pull Request (release/v* → main)
+   ↓
+4. Merge PR → Create GitHub Release (Automatic)
+   ↓
+5. Build VSIX (Automatic - triggered by release)
+   ↓
+6. Publish to Marketplace (Automatic - triggered by build)
+```
+
+**One-time setup:** [Verify Marketplace PAT](verify-marketplace-pat.md) ensures publishing credentials are valid.
+
+## �📁 Workflow Overview
 
 | Workflow | Purpose | Trigger | Documentation |
 | -------- | ------- | ------- | ------------- |
+| **Start Release Branch** | Creates versioned release branches from main | Manual dispatch | [start-release-branch.md](start-release-branch.md) |
+| **Create GitHub Release** | Creates GitHub releases from merged release branches | PR merge (`release/v*` → `main`) | [create-github-release.md](create-github-release.md) |
 | **Build VSIX** | Creates extension packages (.vsix files) | Release creation, Manual dispatch | [build-vsix.md](build-vsix.md) |
 | **Publish to Marketplace** | Publishes extension to VS Code Marketplace | After successful Build VSIX (releases only) | [publish-marketplace.md](publish-marketplace.md) |
-| **Start Release Branch** | Creates versioned release branches from main | Manual dispatch | [start-release-branch.md](start-release-branch.md) |
 | **Verify Marketplace PAT** | Validates marketplace publishing credentials | Manual dispatch | [verify-marketplace-pat.md](verify-marketplace-pat.md) |

--- a/.github/workflows/build-vsix.md
+++ b/.github/workflows/build-vsix.md
@@ -151,3 +151,11 @@ gh run download <run-id>
 - **Manual builds:** Always create artifacts, never attach to releases
 - **Retention:** Artifacts are kept for 30 days
 - **Build consistency:** Same commit always produces same hash in artifact name
+
+## 🔗 Related Workflows
+
+- **Previous step:** [Create GitHub Release](create-github-release.md) - Creates GitHub releases (automatic trigger)
+- **Next step:** [Publish to Marketplace](publish-marketplace.md) - Publishes VSIX to VS Code Marketplace
+- **Release setup:** [Start Release Branch](start-release-branch.md) - Creates versioned release branches
+- **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials
+- **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.github/workflows/create-github-release.md
+++ b/.github/workflows/create-github-release.md
@@ -1,0 +1,139 @@
+# Create GitHub Release Workflow Usage Guide
+
+This document explains how the GitHub Actions workflow automatically creates GitHub releases when release branches are merged into main. This workflow acts as the trigger point for the entire publication chain.
+
+## 🚀 Automatic Release Creation
+
+The workflow automatically triggers when a release branch is merged into main via Pull Request.
+
+**What happens:**
+
+1. Triggers on PR merge from `release/v*` → `main`
+2. Extracts version number from branch name (e.g., `release/v0.2.5` → `0.2.5`)
+3. Parses `CHANGELOG.md` to extract release notes for that version
+4. Creates GitHub Release with tag `v{version}` and extracted changelog content
+5. Triggers downstream workflows: [Build VSIX](build-vsix.md) → [Publish to Marketplace](publish-marketplace.md)
+
+**How to trigger:**
+
+1. Create a release branch using [Start Release Branch](start-release-branch.md) workflow
+2. Make necessary changes on the release branch
+3. Create Pull Request from `release/v{version}` → `main`
+4. Merge the Pull Request
+5. The workflow runs automatically and creates the GitHub release
+
+## 📋 Workflow Chain
+
+```text
+Start Release Branch → Development → PR Merge → Create GitHub Release → Build VSIX → Publish Marketplace
+```
+
+| Step | Workflow | Trigger | Output |
+| ---- | -------- | ------- | ------ |
+| 1 | [Start Release Branch](start-release-branch.md) | Manual dispatch | `release/v{version}` branch |
+| 2 | **Create GitHub Release** | PR Merge (`release/v*` → `main`) | GitHub Release with tag |
+| 3 | [Build VSIX](build-vsix.md) | Release creation | VSIX attached to release |
+| 4 | [Publish to Marketplace](publish-marketplace.md) | Build VSIX completion | Extension published |
+
+## 🔍 Version Detection
+
+The workflow automatically extracts the version from the release branch name:
+
+**Supported branch patterns:**
+
+- `release/v1.2.3` → Version: `1.2.3`, Tag: `v1.2.3`
+- `release/v0.2.5` → Version: `0.2.5`, Tag: `v0.2.5`
+
+**Invalid patterns (workflow will not trigger):**
+
+- `feature/new-feature`
+- `hotfix/bug-fix`
+- `release-v1.2.3` (missing slash)
+- `release/1.2.3` (missing 'v' prefix)
+
+## 📝 CHANGELOG Processing
+
+The workflow automatically extracts release notes from `CHANGELOG.md`:
+
+### Expected CHANGELOG Format
+
+```markdown
+# Change Log
+
+## [Unreleased]
+
+## [0.2.5] - 2026-04-17
+
+### Changed
+- Force Node 24 for workflows
+- Update packages
+
+### Fixed
+- CVE-2026-40186 sanitize-html vulnerability
+
+## [0.2.4] - 2026-03-27
+
+### Added
+- New feature descriptions
+```
+
+### Extraction Logic
+
+- **Start point:** Line containing `## [0.2.5]` (exact version match)
+- **End point:** Next version section `## [0.2.4]` or end of file
+- **Content:** All text between start and end points (excluding version headers)
+- **Fallback:** If no content found, creates generic release notes with CHANGELOG link
+
+## 🛡️ Security & Permissions
+
+### Environment Protection
+
+- **Environment:** `release`
+- **Deployment:** `false` (no deployment protection, but environment restrictions apply)
+- **Required permissions:** Maintainer access to trigger workflow
+
+### GitHub Permissions
+
+The workflow requires:
+
+- **Contents:** `write` (to create releases)
+- **Pull requests:** `read` (to detect PR merges)
+
+## ❌ Troubleshooting
+
+### Workflow Not Triggering
+
+**Check these conditions:**
+
+1. ✅ PR was actually merged (not just closed)
+2. ✅ Source branch follows `release/v*` pattern exactly
+3. ✅ Target branch is `main`
+4. ✅ User has maintainer permissions
+
+### Version Not Detected
+
+**Common issues:**
+
+- Branch name doesn't start with `release/v`
+- Version format is invalid (must be semantic versioning)
+- Extra characters in branch name
+
+### No Release Notes Found
+
+**When this happens:**
+
+- CHANGELOG.md doesn't contain section for the version
+- Version format in CHANGELOG doesn't match branch version
+- Markdown formatting is incorrect
+
+**Fallback behavior:**
+
+- Creates generic release notes with link to CHANGELOG.md
+- Release creation still succeeds
+
+## 🔗 Related Workflows
+
+- **Previous step:** [Start Release Branch](start-release-branch.md) - Creates the release branch
+- **Next step:** [Build VSIX](build-vsix.md) - Builds extension package
+- **Final step:** [Publish to Marketplace](publish-marketplace.md) - Publishes to VS Code Marketplace
+- **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,120 @@
+# GitHub Action to automatically create a GitHub Release when a release/v* branch
+# is merged into main via Pull Request.
+# 
+# Workflow:
+# 1. Triggers when PR from release/v* → main is closed and merged
+# 2. Extracts version number from the release branch name
+# 3. Parses CHANGELOG.md to extract release notes for that version
+# 4. Creates GitHub Release with extracted version and notes
+# 5. This triggers the existing build-vsix.yml → publish-marketplace.yml chain
+#
+# Restricted to maintainers via the "release" GitHub environment
+
+name: Create GitHub Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
+    # Only run if PR was merged AND head branch matches release/v* pattern
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          # Extract version from release/vX.Y.Z → X.Y.Z
+          VERSION=${BRANCH_NAME#release/v}
+          TAG="v${VERSION}"
+          
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Extracted version: ${VERSION} (tag: ${TAG})"
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          # Create a temporary file for the release notes
+          RELEASE_NOTES_FILE=$(mktemp)
+          
+          # Extract the section for this version from CHANGELOG.md
+          # Start from line containing [VERSION] and stop at next version or end of file
+          awk -v version="$VERSION" '
+            BEGIN { found=0; capturing=0 }
+            /^## \[/ {
+              if (found && capturing) {
+                # We found the next version section, stop capturing
+                exit
+              }
+              if ($0 ~ "\\[" version "\\]") {
+                found=1
+                capturing=1
+                next  # Skip the version header line
+              }
+            }
+            capturing && !/^## \[/ {
+              # Capture everything until we hit another version section
+              if (NF > 0 || getline_result != 0) {  # Print non-empty lines and handle empty lines properly
+                print $0
+              }
+            }
+          ' CHANGELOG.md > "$RELEASE_NOTES_FILE"
+          
+          # Remove trailing empty lines
+          sed -i '/^[[:space:]]*$/{ :a; N; s/\n[[:space:]]*$//; ta }' "$RELEASE_NOTES_FILE"
+          
+          # Check if we found any content
+          if [ ! -s "$RELEASE_NOTES_FILE" ]; then
+            echo "Warning: No changelog content found for version $VERSION"
+            echo "## Release $VERSION" > "$RELEASE_NOTES_FILE"
+            echo "" >> "$RELEASE_NOTES_FILE"
+            echo "For detailed changes, please see the [CHANGELOG.md](CHANGELOG.md)." >> "$RELEASE_NOTES_FILE"
+          fi
+          
+          echo "release-notes-file=$RELEASE_NOTES_FILE" >> $GITHUB_OUTPUT
+          echo "Release notes extracted:"
+          cat "$RELEASE_NOTES_FILE"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          RELEASE_NOTES_FILE="${{ steps.changelog.outputs.release-notes-file }}"
+          
+          echo "Creating release $TAG..."
+          
+          gh release create "$TAG" \
+            --title "Release $VERSION" \
+            --notes-file "$RELEASE_NOTES_FILE" \
+            --target main
+          
+          echo "✅ GitHub Release $TAG created successfully!"
+          echo "This will now trigger the build-vsix.yml workflow to build and attach the VSIX."
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # Clean up temporary files
+          RELEASE_NOTES_FILE="${{ steps.changelog.outputs.release-notes-file }}"
+          if [ -n "$RELEASE_NOTES_FILE" ] && [ -f "$RELEASE_NOTES_FILE" ]; then
+            rm -f "$RELEASE_NOTES_FILE"
+          fi

--- a/.github/workflows/publish-marketplace.md
+++ b/.github/workflows/publish-marketplace.md
@@ -36,3 +36,11 @@ This workflow is protected by the 'release' environment which should be configur
 - **release:** Environment with protection rules
   - Configure deployment protection rules
   - Add required reviewers who can approve publishing
+
+## 🔗 Related Workflows
+
+- **Previous step:** [Build VSIX](build-vsix.md) - Creates VSIX packages (automatic trigger)
+- **Release creation:** [Create GitHub Release](create-github-release.md) - Creates GitHub releases
+- **Release setup:** [Start Release Branch](start-release-branch.md) - Creates versioned release branches
+- **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials before use
+- **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.github/workflows/start-release-branch.md
+++ b/.github/workflows/start-release-branch.md
@@ -59,3 +59,11 @@ gh workflow run start-release-branch.yml -f bump_type=premajor
 - **Use case:** Breaking changes, major architectural updates
 - **Example:** 1.0.0 → 2.0.0-dev0
 - **When to use:** Significant changes that may break compatibility
+
+## 🔗 Related Workflows
+
+- **Next step:** [Create GitHub Release](create-github-release.md) - Automatically creates releases when you merge the release branch
+- **Build step:** [Build VSIX](build-vsix.md) - Builds extension packages from releases
+- **Final step:** [Publish to Marketplace](publish-marketplace.md) - Publishes to VS Code Marketplace
+- **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials
+- **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.github/workflows/verify-marketplace-pat.md
+++ b/.github/workflows/verify-marketplace-pat.md
@@ -94,3 +94,11 @@ The PAT must have:
 2. Update VSCE_PAT secret
 3. Run verify workflow to confirm
 4. Revoke old PAT from marketplace
+
+## 🔗 Related Workflows
+
+- **Uses this token:** [Publish to Marketplace](publish-marketplace.md) - Publishes VSIX to VS Code Marketplace
+- **Triggers publishing:** [Build VSIX](build-vsix.md) - Creates VSIX packages
+- **Creates releases:** [Create GitHub Release](create-github-release.md) - Creates GitHub releases
+- **Release setup:** [Start Release Branch](start-release-branch.md) - Creates versioned release branches
+- **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,6 +17,10 @@ src/**
 out/**
 node_modules/**
 !node_modules/ssh2/**
+!node_modules/asn1/**
+!node_modules/safer-buffer/**
+!node_modules/bcrypt-pbkdf/**
+!node_modules/tweetnacl/**
 dist/*.map
 esbuild.js
 vsc-extension-quickstart.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Add workflow to create release on PR merge to main
 
+### Fixwed
+
+- uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
+
 ## [0.2.5] - 2026-04-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## Changed
+
+- Add workflow to create release on PR merge to main
+
 ## [0.2.5] - 2026-04-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Add workflow to create release on PR merge to main
 
-### Fixwed
+### Fixed
 
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
+- Fix missing ssh2 transitive dependencies (asn1, safer-buffer, bcrypt-pbkdf, tweetnacl) in `.vscodeignore`
 
 ## [0.2.5] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-13
+
 ### Changed
 
 - Add workflow to create release on PR merge to main
@@ -15,6 +17,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
 - Fix missing ssh2 transitive dependencies (asn1, safer-buffer, bcrypt-pbkdf, tweetnacl) in `.vscodeignore`
 - CVE-2026-6321 fast-uri vulnerable to path traversal via percent-encoded dot segments
+- CVE-2026-6322 fast-uri vulnerable to host confusion via percent-encoded authority delimiters
 
 ## [0.2.5] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Add workflow to create release on PR merge to main
 
@@ -14,6 +14,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
 - Fix missing ssh2 transitive dependencies (asn1, safer-buffer, bcrypt-pbkdf, tweetnacl) in `.vscodeignore`
+- CVE-2026-6321 fast-uri vulnerable to path traversal via percent-encoded dot segments
 
 ## [0.2.5] - 2026-04-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.6-dev.2",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.6-dev.2",
+      "version": "0.2.6",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.5",
+  "version": "0.2.6-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.5",
+      "version": "0.2.6-dev.0",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,18 +202,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.3.tgz",
-      "integrity": "sha512-LqT8mRZpEils9zGR9eW+Ljqifh2aMA99UF/X0jxIKDYZeHr6onlHwhVP4xHCeLhh55BI63JCbdf1iWJbMh1mPw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6202,16 +6211,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.6-dev.1",
+  "version": "0.2.6-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.6-dev.1",
+      "version": "0.2.6-dev.2",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.6-dev.0",
+  "version": "0.2.6-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.6-dev.0",
+      "version": "0.2.6-dev.1",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.6-dev.2",
+  "version": "0.2.6",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.6-dev.1",
+  "version": "0.2.6-dev.2",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.5",
+  "version": "0.2.6-dev.0",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.6-dev.0",
+  "version": "0.2.6-dev.1",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",


### PR DESCRIPTION
## [0.2.6] - 2026-05-13

### Changed

- Add workflow to create release on PR merge to main

### Fixed

- uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided
- Fix missing ssh2 transitive dependencies (asn1, safer-buffer, bcrypt-pbkdf, tweetnacl) in `.vscodeignore`
- CVE-2026-6321 fast-uri vulnerable to path traversal via percent-encoded dot segments
- CVE-2026-6322 fast-uri vulnerable to host confusion via percent-encoded authority delimiters
