### PR TITLE
Release/v0.2.7

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,12 +15,18 @@ The workflows follow this automated chain for releasing extensions:
    ↓
 4. Merge PR → Create GitHub Release (Automatic)
    ↓
-5. Build VSIX (Automatic - triggered by release)
+5. Build VSIX (Automatic - called by Create GitHub Release via workflow_call)
    ↓
-6. Publish to Marketplace (Automatic - triggered by build)
+6. Publish to Marketplace (Automatic - triggered by workflow_run on completion)
 ```
 
 **One-time setup:** [Verify Marketplace PAT](verify-marketplace-pat.md) ensures publishing credentials are valid.
+
+### Why workflow_call instead of event chaining?
+
+GitHub Actions has a deliberate security limitation: **events created by the default `GITHUB_TOKEN` do not trigger other workflows**. This prevents infinite recursive workflow runs.
+
+Previously, "Create GitHub Release" used `GITHUB_TOKEN` to call `gh release create`, which meant the resulting `release: created` event was suppressed and "Build VSIX" was never triggered. The fix uses `workflow_call` to invoke Build VSIX directly as a reusable workflow within the same run, bypassing this limitation entirely.
 
 ## �📁 Workflow Overview
 
@@ -28,6 +34,6 @@ The workflows follow this automated chain for releasing extensions:
 | -------- | ------- | ------- | ------------- |
 | **Start Release Branch** | Creates versioned release branches from main | Manual dispatch | [start-release-branch.md](start-release-branch.md) |
 | **Create GitHub Release** | Creates GitHub releases from merged release branches | PR merge (`release/v*` → `main`) | [create-github-release.md](create-github-release.md) |
-| **Build VSIX** | Creates extension packages (.vsix files) | Release creation, Manual dispatch | [build-vsix.md](build-vsix.md) |
-| **Publish to Marketplace** | Publishes extension to VS Code Marketplace | After successful Build VSIX (releases only) | [publish-marketplace.md](publish-marketplace.md) |
+| **Build VSIX** | Creates extension packages (.vsix files) | Release creation, workflow_call, Manual dispatch | [build-vsix.md](build-vsix.md) |
+| **Publish to Marketplace** | Publishes extension to VS Code Marketplace | After successful Build VSIX or Create GitHub Release (via workflow_run) | [publish-marketplace.md](publish-marketplace.md) |
 | **Verify Marketplace PAT** | Validates marketplace publishing credentials | Manual dispatch | [verify-marketplace-pat.md](verify-marketplace-pat.md) |

--- a/.github/workflows/build-vsix.md
+++ b/.github/workflows/build-vsix.md
@@ -4,15 +4,25 @@ This document explains how to use the GitHub Actions workflow for building the v
 
 ## 🚀 Automatic Release Build
 
-The workflow automatically triggers when a new release is created on GitHub.
+The workflow triggers automatically in two scenarios:
+
+1. **Via `workflow_call` from Create GitHub Release** (primary path): When a release branch is merged into main, the Create GitHub Release workflow calls this workflow directly as a reusable workflow, passing the release tag name.
+2. **Via `release: created` event** (fallback): When a GitHub release is created manually (bypassing the PR flow), the workflow triggers independently.
 
 **What happens:**
 
+- Checks out the release tag
 - Builds VSIX from the release tag
 - Attaches the VSIX file to the GitHub release
 - Uses official release naming (matches GitHub release)
 
-**How to trigger:**
+**How to trigger (automatic via PR merge):**
+
+1. Merge a `release/v*` branch into main
+2. Create GitHub Release workflow runs and calls this workflow
+3. VSIX is built and attached to the release
+
+**How to trigger (manual release):**
 
 1. Create a new release on GitHub (via web UI or `gh release create`)
 2. The workflow runs automatically
@@ -138,7 +148,8 @@ gh run download <run-id>
 
 | Scenario | Command | Output |
 | -------- | ------- | ------ |
-| Auto release | Create GitHub release | VSIX attached to release |
+| Auto release (via PR merge) | Merge `release/v*` PR into main | VSIX attached to release |
+| Auto release (manual) | Create GitHub release | VSIX attached to release |
 | Build main | `gh workflow run build-vsix.yml --ref main` | `vscode-wago-cc100-v{version}-{hash}` |
 | Build branch | `gh workflow run build-vsix.yml --ref feature/abc` | `vscode-wago-cc100-v{version}-{hash}` |
 | Build commit | `gh workflow run build-vsix.yml --ref a1b2c3d4` | `vscode-wago-cc100-v{version}-{hash}` |
@@ -154,8 +165,8 @@ gh run download <run-id>
 
 ## 🔗 Related Workflows
 
-- **Previous step:** [Create GitHub Release](create-github-release.md) - Creates GitHub releases (automatic trigger)
-- **Next step:** [Publish to Marketplace](publish-marketplace.md) - Publishes VSIX to VS Code Marketplace
+- **Caller:** [Create GitHub Release](create-github-release.md) - Calls this workflow via `workflow_call` after creating a release
+- **Next step:** [Publish to Marketplace](publish-marketplace.md) - Publishes VSIX to VS Code Marketplace (triggered via `workflow_run`)
 - **Release setup:** [Start Release Branch](start-release-branch.md) - Creates versioned release branches
 - **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials
 - **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -10,6 +10,12 @@ env:
 on:
   release:
     types: [created]
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Release tag name (e.g. v0.2.6)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -24,7 +30,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.commit_sha || github.sha }}
+        ref: ${{ inputs.tag_name || inputs.commit_sha || github.sha }}
 
     - name: Get version and commit info for manual builds
       if: github.event_name == 'workflow_dispatch'
@@ -77,12 +83,13 @@ jobs:
         echo "vsix-file=$VSIX_FILE" >> $GITHUB_OUTPUT
         echo "Found VSIX file: $VSIX_FILE"
 
-    - name: Upload VSIX to release (automatic)
-      if: github.event_name == 'release'
+    - name: Upload VSIX to release
+      if: github.event_name == 'release' || inputs.tag_name
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release upload ${{ github.event.release.tag_name }} ${{ steps.find-vsix.outputs.vsix-file }} --clobber
+        TAG="${{ github.event.release.tag_name || inputs.tag_name }}"
+        gh release upload "$TAG" ${{ steps.find-vsix.outputs.vsix-file }} --clobber
 
     - name: Upload VSIX as workflow artifact (manual builds only)
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/create-github-release.md
+++ b/.github/workflows/create-github-release.md
@@ -12,7 +12,8 @@ The workflow automatically triggers when a release branch is merged into main vi
 2. Extracts version number from branch name (e.g., `release/v0.2.5` → `0.2.5`)
 3. Parses `CHANGELOG.md` to extract release notes for that version
 4. Creates GitHub Release with tag `v{version}` and extracted changelog content
-5. Triggers downstream workflows: [Build VSIX](build-vsix.md) → [Publish to Marketplace](publish-marketplace.md)
+5. Calls [Build VSIX](build-vsix.md) directly via `workflow_call` to build and attach the VSIX
+6. On completion, [Publish to Marketplace](publish-marketplace.md) is triggered via `workflow_run`
 
 **How to trigger:**
 
@@ -25,15 +26,25 @@ The workflow automatically triggers when a release branch is merged into main vi
 ## 📋 Workflow Chain
 
 ```text
-Start Release Branch → Development → PR Merge → Create GitHub Release → Build VSIX → Publish Marketplace
+Start Release Branch → Development → PR Merge → Create GitHub Release → Build VSIX (workflow_call) → Publish Marketplace (workflow_run)
 ```
 
 | Step | Workflow | Trigger | Output |
 | ---- | -------- | ------- | ------ |
 | 1 | [Start Release Branch](start-release-branch.md) | Manual dispatch | `release/v{version}` branch |
 | 2 | **Create GitHub Release** | PR Merge (`release/v*` → `main`) | GitHub Release with tag |
-| 3 | [Build VSIX](build-vsix.md) | Release creation | VSIX attached to release |
-| 4 | [Publish to Marketplace](publish-marketplace.md) | Build VSIX completion | Extension published |
+| 3 | [Build VSIX](build-vsix.md) | `workflow_call` from this workflow | VSIX attached to release |
+| 4 | [Publish to Marketplace](publish-marketplace.md) | `workflow_run` on completion of this workflow | Extension published |
+
+## ⚠️ GITHUB_TOKEN Limitation (Design Note)
+
+This workflow uses `workflow_call` (reusable workflow) to invoke Build VSIX instead of relying on the `release: created` event. The reason:
+
+> **Events created by the default `GITHUB_TOKEN` do not trigger other workflows.** This is a deliberate GitHub security measure to prevent infinite recursive workflow runs.
+
+Since the `gh release create` step runs with `GITHUB_TOKEN`, the resulting `release: created` webhook event is suppressed by GitHub. Any workflow listening for `release: types: [created]` (like Build VSIX originally did) will **not** be triggered.
+
+The solution is to call Build VSIX directly via `workflow_call`, which runs it as a reusable workflow within the same workflow run. The downstream Publish to Marketplace workflow then picks up the completion via `workflow_run`, which is emitted by GitHub’s Actions infrastructure (not by the token) and is therefore not subject to this limitation.
 
 ## 🔍 Version Detection
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -6,7 +6,8 @@
 # 2. Extracts version number from the release branch name
 # 3. Parses CHANGELOG.md to extract release notes for that version
 # 4. Creates GitHub Release with extracted version and notes
-# 5. This triggers the existing build-vsix.yml → publish-marketplace.yml chain
+# 5. Calls build-vsix.yml (via workflow_call) to build and attach the VSIX
+# 6. On completion, publish-marketplace.yml is triggered via workflow_run
 #
 # Restricted to maintainers via the "release" GitHub environment
 
@@ -23,6 +24,8 @@ jobs:
     environment:
       name: release
       deployment: false
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     # Only run if PR was merged AND head branch matches release/v* pattern
     if: >-
       github.event.pull_request.merged == true &&
@@ -118,3 +121,10 @@ jobs:
           if [ -n "$RELEASE_NOTES_FILE" ] && [ -f "$RELEASE_NOTES_FILE" ]; then
             rm -f "$RELEASE_NOTES_FILE"
           fi
+
+  build-vsix:
+    needs: create-release
+    uses: ./.github/workflows/build-vsix.yml
+    with:
+      tag_name: ${{ needs.create-release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/publish-marketplace.md
+++ b/.github/workflows/publish-marketplace.md
@@ -4,7 +4,10 @@ This document explains how the GitHub Actions workflow for publishing the vscode
 
 ## 🚀 Automatic Publishing
 
-The workflow automatically triggers after the "Build VSIX" workflow completes successfully for a release event.
+The workflow automatically triggers after a release-related workflow completes successfully. It listens for `workflow_run` completion events from both:
+
+- **"Create GitHub Release"** — the primary path when a release branch is merged via PR
+- **"Build VSIX"** — the fallback path when a GitHub release is created manually
 
 **What happens:**
 
@@ -14,10 +17,13 @@ The workflow automatically triggers after the "Build VSIX" workflow completes su
 
 **How it triggers:**
 
-1. Create a GitHub release (which triggers Build VSIX workflow)
-2. After Build VSIX succeeds, this workflow automatically starts
-3. Manual approval is required before publishing (release environment protection)
-4. Extension is published to the marketplace using the VSCE_PAT token
+1. A release workflow completes (either via PR merge chain or manual release creation)
+2. GitHub emits a `workflow_run` event (this is a system-level event from GitHub Actions infrastructure, not subject to `GITHUB_TOKEN` limitations)
+3. This workflow starts and resolves the release tag from the triggering workflow's branch:
+   - If branch is `release/vX.Y.Z` (from Create GitHub Release): extracts tag as `vX.Y.Z`
+   - If branch is `vX.Y.Z` (from direct release trigger): uses it as-is
+4. Manual approval is required before publishing (release environment protection)
+5. Extension is published to the marketplace using the VSCE_PAT token
 
 ## 🛡️ Security & Environment Protection
 
@@ -39,8 +45,8 @@ This workflow is protected by the 'release' environment which should be configur
 
 ## 🔗 Related Workflows
 
-- **Previous step:** [Build VSIX](build-vsix.md) - Creates VSIX packages (automatic trigger)
-- **Release creation:** [Create GitHub Release](create-github-release.md) - Creates GitHub releases
+- **Triggering workflow (primary):** [Create GitHub Release](create-github-release.md) - Creates GitHub releases and builds VSIX (triggers this workflow via `workflow_run`)
+- **Triggering workflow (fallback):** [Build VSIX](build-vsix.md) - Creates VSIX packages (triggers this workflow when run standalone on a `release` event)
 - **Release setup:** [Start Release Branch](start-release-branch.md) - Creates versioned release branches
 - **Utility:** [Verify Marketplace PAT](verify-marketplace-pat.md) - Validates publishing credentials before use
 - **Overview:** [All Workflows](README.md) - Complete workflow documentation

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -15,7 +15,7 @@ env:
 
 on:
   workflow_run:
-    workflows: ["Build VSIX"]
+    workflows: ["Build VSIX", "Create GitHub Release"]
     types:
       - completed
 
@@ -25,18 +25,29 @@ jobs:
     environment:
       name: release
       deployment: true
-    # Only run when Build VSIX succeeded AND was triggered by a release event
+    # Only run when the triggering workflow succeeded AND was a release-related event
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'release'
+      (github.event.workflow_run.event == 'release' ||
+       github.event.workflow_run.name == 'Create GitHub Release')
 
     steps:
       - name: Download VSIX from release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # For release-triggered workflows, head_branch holds the tag name
-          TAG="${{ github.event.workflow_run.head_branch }}"
+          # Determine the release tag based on the triggering workflow
+          # For release-triggered Build VSIX: head_branch is the tag directly
+          # For PR-triggered Create GitHub Release: head_branch is release/vX.Y.Z
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [[ "$BRANCH" == release/v* ]]; then
+            TAG="v${BRANCH#release/v}"
+          elif [[ "$BRANCH" == v* ]]; then
+            TAG="$BRANCH"
+          else
+            echo "Error: Cannot determine release tag from branch: $BRANCH"
+            exit 1
+          fi
           echo "Downloading VSIX from release: $TAG"
           gh release download "$TAG" \
             --repo "${{ github.repository }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - CVE-2026-44990 Apostrophe has default XSS via `xmp` raw-text passthrough in `sanitize-html`
+- CVE-2026-8723 qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set
 
 ## [0.2.6] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - Update npm packages
+- Fix workflow chain: use `workflow_call` to invoke Build VSIX from Create GitHub Release (events created by `GITHUB_TOKEN` do not trigger other workflows)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-05-27
+
 ### Changed
 
 - Update npm packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- CVE-2026-44990 Apostrophe has default XSS via `xmp` raw-text passthrough in `sanitize-html`
+
 ## [0.2.6] - 2026-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- Update npm packages
+
 ### Fixed
 
 - CVE-2026-44990 Apostrophe has default XSS via `xmp` raw-text passthrough in `sanitize-html`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.6",
+  "version": "0.2.7-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.6",
+      "version": "0.2.7-dev.0",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.7-dev.0",
       "license": "see LICENSE file",
       "dependencies": {
-        "sanitize-html": "^2.17.3",
+        "sanitize-html": "^2.17.4",
         "ssh2": "^1.16.0",
         "tar": "^7.5.10",
         "yaml": "^2.8.3"
@@ -1955,6 +1955,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3774,6 +3780,15 @@
         "prebuild-install": "^7.0.1"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5111,15 +5126,16 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.7-dev.1",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.7-dev.1",
+      "version": "0.2.7",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wago-cc100",
-  "version": "0.2.7-dev.0",
+  "version": "0.2.7-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wago-cc100",
-      "version": "0.2.7-dev.0",
+      "version": "0.2.7-dev.1",
       "license": "see LICENSE file",
       "dependencies": {
         "sanitize-html": "^2.17.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,22 +179,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.7.0.tgz",
-      "integrity": "sha512-uYbJ0YarxkVGWEq814BysJry/IPvpDNkVKmc2bMZp4G+igUQkJ5nlFirycwPGUeA9ICLQqCxqExCA1Z1E07bPA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.0"
+        "@azure/msal-common": "16.6.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.0.tgz",
-      "integrity": "sha512-i3eS/5pmxDbIU/mLMENs88Qg3k6XxqJytJy6PpB7L1tCBjdXHJDadCD3Hu1TyTooe7iQo7CYqbocgL/l/8u90g==",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -202,37 +202,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
-      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.2",
+        "@azure/msal-common": "16.6.2",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
-      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -241,9 +231,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -940,24 +930,24 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.4.tgz",
-      "integrity": "sha512-bVtB6VEy9U9DpW8cTt25k5T+lz86zV5w6ImePZqY1AXzSuPhqQNT77lkMPxonXzUducEIlSvUu3o7sKw3y9+Sw==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
+      "integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.4.tgz",
-      "integrity": "sha512-D9qJedKBLmAo+kiudop4UKgSxXMi4O8U86KrCidVXZ9RsK0NSVIw6+r2rlMUOExq79iEY81FRENyzmNVRxDBsg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
+      "integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.5.4",
-        "@textlint/resolver": "15.5.4",
-        "@textlint/types": "15.5.4",
+        "@textlint/module-interop": "15.7.1",
+        "@textlint/resolver": "15.7.1",
+        "@textlint/types": "15.7.1",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
         "js-yaml": "^4.1.1",
@@ -1000,37 +990,37 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.4.tgz",
-      "integrity": "sha512-JyAUd26ll3IFF87LP0uGoa8Tzw5ZKiYvGs6v8jLlzyND1lUYCI4+2oIAslrODLkf0qwoCaJrBQWM3wsw+asVGQ==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
+      "integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.4.tgz",
-      "integrity": "sha512-5GUagtpQuYcmhlOzBGdmVBvDu5lKgVTjwbxtdfoidN4OIqblIxThJHHjazU+ic+/bCIIzI2JcOjHGSaRmE8Gcg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
+      "integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/types": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.4.tgz",
-      "integrity": "sha512-mY28j2U7nrWmZbxyKnRvB8vJxJab4AxqOobLfb6iozrLelJbqxcOTvBQednadWPfAk9XWaZVMqUr9Nird3mutg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
+      "integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.4"
+        "@textlint/ast-node-types": "15.7.1"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1085,9 +1075,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.116.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
-      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1117,9 +1107,9 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.0.tgz",
-      "integrity": "sha512-Dfql2kgPHpTKS+G4wTqYBKzK1KqX2gMxTC9dpnYge+aIZL+thh1Z6GXs4zOtNwo7DCPmS7BCfaHUAmNLxKiXkw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
+      "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1319,9 +1309,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2370,9 +2360,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2604,9 +2594,9 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,9 +2773,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2964,9 +2954,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3229,13 +3219,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3709,9 +3699,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3800,10 +3790,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -3902,15 +3902,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -4087,16 +4097,16 @@
       "license": "ISC"
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4127,9 +4137,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4622,9 +4632,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4714,9 +4724,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4733,7 +4743,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5044,15 +5054,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -5259,9 +5269,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5344,9 +5354,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5859,9 +5869,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -6174,9 +6184,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6184,9 +6194,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6437,9 +6447,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -6452,9 +6462,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4809,9 +4809,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.6",
+  "version": "0.2.7-dev.0",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.7-dev.1",
+  "version": "0.2.7",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wago-cc100",
   "displayName": "WAGO CC100",
   "description": "VS Code extension to develop python scripts for the WAGO CC100 programmable logic controller",
-  "version": "0.2.7-dev.0",
+  "version": "0.2.7-dev.1",
   "author": {
     "name": "WAGO Education",
     "email": "ausbildungminden@wago.com",

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     }
   },
   "dependencies": {
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.4",
     "ssh2": "^1.16.0",
     "tar": "^7.5.10",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## [0.2.7] - 2026-05-27

### Changed

- Update npm packages
- Fix workflow chain: use `workflow_call` to invoke Build VSIX from Create GitHub Release (events created by `GITHUB_TOKEN` do not trigger other workflows)

### Fixed

- CVE-2026-44990 Apostrophe has default XSS via `xmp` raw-text passthrough in `sanitize-html`
- CVE-2026-8723 qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set
